### PR TITLE
Fix broken parsing of findscu output

### DIFF
--- a/autobidsportal/dcm4cheutils.py
+++ b/autobidsportal/dcm4cheutils.py
@@ -147,7 +147,7 @@ class Dcm4cheUtils():
         ]
 
         output_re = (
-            r"(\([\dabcdef]{4},[\dabcdef]{4}\)) [A-Z]{2} \[([\w ]*)\] (\w+)"
+            r"(\([\dABCDEF]{4},[\dABCDEF]{4}\)) [A-Z]{2} \[(.*)\] (\w+)"
         )
 
         out_dicts = []


### PR DESCRIPTION
The regular expression used to parse findscu output failed in some instances, which this PR should fix.