### PR TITLE
Make output parsing more robust

### DIFF
--- a/autobidsportal/dcm4cheutils.py
+++ b/autobidsportal/dcm4cheutils.py
@@ -178,6 +178,10 @@ class Dcm4cheUtils():
                         "tag_value": match.group(2)
                     }
                 )
+            if len(out_dicts) != len(output_fields):
+                raise Dcm4cheError(
+                    "Missing output fields in dataset {}".format(out_dicts)
+                )
             grouped_dicts.append(out_dicts)
 
         return grouped_dicts


### PR DESCRIPTION
This PR changes the `findscu` output parsing logic to be a bit more robust, ensuring that the output tags are grouped properly and that all requested fields are present in each dataset. It also omits the blank dataset included first for each request.