### PR TITLE
Fix tar file parsing

### DIFF
--- a/autobidsportal/tasks.py
+++ b/autobidsportal/tasks.py
@@ -81,7 +81,7 @@ def get_info_from_cfmm2tar(study_id):
             with open(result[1], "r", encoding="utf-8") as uid_file:
                 uid = uid_file.read()
             cfmm2tar = Cfmm2tarOutput(
-                study_id,
+                study_id=study_id,
                 tar_file=result[0],
                 uid=uid,
                 date=datetime(


### PR DESCRIPTION
There were a few lingering issues preventing the portal from dealing with cfmm2tar properly. This simplifies the output file parsing code and addresses those issues.