### PR TITLE
Use findscu XML output

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,4 +20,5 @@ install_requires =
     pytest~=6.2
     SQLAlchemy~=1.4
     WTForms~=2.3
+    defusedxml~=0.7
 include_package_data = True


### PR DESCRIPTION
findscu's printed output gets cut off at 72 characters, so the previous output parsing logic couldn't handle long DICOM tag values. This PR uses findscu's XML output instead, parsing output XML to generate the internal representation of the result.