### PR TITLE
Add workflows for version bumping / releasing, CI

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,27 @@
+---
+name-template: $RESOLVED_VERSION
+tag-template: v$RESOLVED_VERSION
+filter-by-commitish: true
+template: |
+  ## Changes
+  $CHANGES
+categories:
+  - title: 🚀 Features
+    labels: [breaking, enhancement]
+  - title: 🐛 Bug Fixes
+    labels: [bug]
+  - title: 🧰 Maintenance
+    labels: [maintenance, test]
+  - title: 📝 Documentation
+    labels: [documentation]
+exclude-labels: [skip_changelog]
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: \<*_& # You can add  # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels: [breaking]
+  minor:
+    labels: [enhancement]
+  patch:
+    labels: [maintenance, bug, test, documentation]
+  default: patch

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,11 @@
+---
+name: Bump version
+on:
+  pull_request_target:
+    types: [closed]
+jobs:
+  bump-version:
+    if: github.event.pull_request.merged == true
+    uses: khanlab/actions/.github/workflows/workflow-version_task-semverGithub.yml@v0.2.1
+    secrets:
+      BP-PAT: ${{ secrets.BP_PAT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+---
+name: Release package
+on:
+  workflow_dispatch:
+    inputs:
+      comments:
+        description: Comments
+        required: false
+jobs:
+  release_package:
+    uses: khanlab/actions/.github/workflows/workflow-release_task-publishGithub.yml@v0.2.1
+    with:
+      comments: ${{ github.event.inputs.comments }}
+    secrets:
+      BP-PAT: ${{ secrets.BP_PAT_TOKEN }}


### PR DESCRIPTION
Wasn't originally planning on this, but added in additional CI workflows to help with versioning from PRs, making the process less manual. This will help with building the documentations as well.

Adds bump_version workflow and release-drafter for creating notes. Also incorporates some CI changes that were already introduced in #192.