### PR TITLE
Update reusable workflows to v0.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Setup environment
-        uses: khanlab/actions/.github/actions/action-setup_task-installPyProject@v0.2.0
+        uses: khanlab/actions/.github/actions/action-setup_task-installPyProject@v0.2.1
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Setup environment
-        uses: khanlab/actions/.github/actions/action-setup_task-installPyProject@v0.2.0
+        uses: khanlab/actions/.github/actions/action-setup_task-installPyProject@v0.2.1
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Forgot to update to v0.2.1 in the `installPyProject` workflow which fixed the release bug.