### PR TITLE
Create actions dispatch event

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,0 +1,27 @@
+# Create a dispatch event to trigger workflows in associated repos
+on:
+  workflow_dispatch:
+  push: # Trigger event on new tagged versions
+    tags: [v*]
+
+jobs:
+  dispatch:
+    runs-on: ubutun-latest
+
+    steps:
+      - name: Get latest release tag
+        run: |
+          echo "LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)" >> $GITHUB_ENV
+
+      - name: Create dispatch event for autobids-docs
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.BP_PAT_TOKEN }}
+          script: |
+            const result = await github.rest.repos.createDispatchEvent({
+              owner: 'khanlab',
+              repo: 'autobids-docs',
+              event_type: 'autobidsportal_release'
+              client_payload:{"version": "${{ env.LATEST_TAG}}"}
+            })
+            console.log(result)

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -22,6 +22,19 @@ jobs:
               owner: 'khanlab',
               repo: 'autobids-docs',
               event_type: 'autobidsportal_release'
-              client_payload:{"version": "${{ env.LATEST_TAG}}"}
+              client_payload:{"version": "${{ env.LATEST_TAG }}"}
             })
-            console.log(result)
+            console.log(result);
+
+      - name: Create dispatch event for autobids-dglobus
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.BP_PAT_TOKEN }}
+          script: |
+            const result = await github.rest.repos.createDispatchEvent({
+              owner: 'khanlab',
+              repo: 'autobids-globus',
+              event_type: 'autobidsportal_release'
+              client_payload:{"version": "${{ env.LATEST_TAG }}"}
+            })
+            console.log(result);


### PR DESCRIPTION
This PR adds an actions workflow to create a trigger for downstream workflows in the autobids-docs and autobids-globus repositories. Main purpose for this is to keep all of the relevant repos synced in terms of updates and versioning.