### PR TITLE
Use overwrite flag for `handle_cfmm2tar`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ ignore = [
     "D213",
     "PGH003",
     "PTH123",
+    "FBT001",
+    "FBT002",
+    "FBT003",
 ]
 unfixable = ["F841"]
 


### PR DESCRIPTION
Add a safety `overwrite` flag for dealing with overwriting "existing" cfmm2tar files. This `overwrite` is useful when new tars are found, but an existing tar already exists in the dataset - likely due to an unexpected shutdown, enabling the old file to be removed from the dataset, and the new file to be added. For some reason, deleting / removing via the datalad.api does not work here as the file is "not found".

This allows the same function to be used to `run_cfmm2tar` without overwriting if the target is not new (which it was previously doing).