### PR TITLE
Add message to authorize bidsdump user

### DIFF
--- a/autobidsportal/routes.py
+++ b/autobidsportal/routes.py
@@ -123,7 +123,11 @@ def new_study() -> str | Response:
         db.session.add(study)  # pyright: ignore
         db.session.commit()  # pyright: ignore
 
-        flash("Thanks, the survey has been submitted!")
+        flash(
+            "Thanks, the survey has been submitted!<br/>"
+            "If you haven't already, please add 'bidsdump' as an authorized user to "
+            "your study on the CFMM DICOM server.",
+        )
         send_email(
             "New study request",
             (
@@ -1268,7 +1272,7 @@ def dicom_verify(study_id: int, method: str):
         err_cause = (
             err.__cause__.stderr  # pyright: ignore
             if err.__cause__ is not None
-            else ""
+            else ""  # pyright: ignore
         )
         current_app.logger.warning(
             "Failed to get DICOM info for study %i: %s",

--- a/autobidsportal/templates/index.html
+++ b/autobidsportal/templates/index.html
@@ -18,10 +18,26 @@
               format.
             </p>
             <p>
-              Request a new study from the
-              <a href="{{ url_for("portal_blueprint.new_study") }}">"New Study"</a>
-              tab. To interact with your study, you'll need to create an account
-              and log in. An admin will review the new study, enable it, and grant
+              To create request CFMM autobids conversion:
+              <ol type="1">
+                <li>
+                  Request a new study from the
+                  <a href="{{ url_for("portal_blueprint.new_study") }}">"New Study"</a>
+                  tab. To interact with your study, you'll need to create an account
+                  and log in.
+                </li>
+                <li>
+                  Have the PI (or study manager) add "bidsdump" as an authorized user
+                  for the study on the CFMM DICOM study. A step-by-step guide can be found
+                  <a href="https://github.com/khanlab/autobids/wiki/Granting-access-to-bidsdump"
+                     target="_blank">here</a>.
+                </li>
+                <li>
+                  Sign up for a <a href="https://app.globus.org/" target="_blank">Globus</a> account and download
+                  <a href="https://www.globus.org/globus-connect-personal" target="_blank">Globus Connect Personal</a>.
+                </li>
+              </ol>
+              An admin will review the new study, enable it, and grant
               you access if there are no issues.
             </p>
           </div>


### PR DESCRIPTION
This PR introduces a small change, adding instructions, including authorizing the "bidsdump" user (copied from cbs-discourse) on index page, as well as a reminder in the flash message after a valid new study form has been submitted.