### PR TITLE
Add getting started page

### DIFF
--- a/autobidsportal/routes.py
+++ b/autobidsportal/routes.py
@@ -396,8 +396,7 @@ def admin(user_id: int) -> str:
     # Get all available studies
     all_studies = db.session.query(Study).all()  # pyright: ignore
     form.choices.choices = [
-        (study.id, f"{study.principal}^{study.project_name}")
-        for study in all_studies
+        (study.id, f"{study.principal}^{study.project_name}") for study in all_studies
     ]
     removal_form.choices_to_remove.choices = form.choices.choices
 
@@ -427,9 +426,7 @@ def admin(user_id: int) -> str:
             db.session.commit()  # pyright: ignore
         # If valid form, remove user authorization from selected studies
         if removal_form.validate_on_submit():
-            for (
-                study_id
-            ) in removal_form.choices_to_remove.data:  # pyright: ignore
+            for study_id in removal_form.choices_to_remove.data:  # pyright: ignore
                 study = Study.query.get(study_id)
                 if user in study.users_authorized:
                     study.users_authorized.remove(user)
@@ -539,9 +536,7 @@ def answer_info(study_id: int):
 
     # Render form for running tar2bids and handle processing
     form = Tar2bidsRunForm()
-    form.tar_files.choices = [
-        (tar_file.id, "Yes") for tar_file in cfmm2tar_files
-    ]
+    form.tar_files.choices = [(tar_file.id, "Yes") for tar_file in cfmm2tar_files]
     form.tar_files.default = []
     form.process()  # pyright: ignore
 
@@ -633,10 +628,7 @@ def study_config(study_id: int) -> str:
                 / current_app.config["HEURISTIC_DIR_PATH"]
             ).iterdir()
         ]
-        + [
-            (heuristic, f"{heuristic} (container)")
-            for heuristic in DEFAULT_HEURISTICS
-        ],
+        + [(heuristic, f"{heuristic} (container)") for heuristic in DEFAULT_HEURISTICS],
         key=lambda option: option[1].lower(),
     )
 
@@ -748,9 +740,7 @@ def delete_cfmm2tar(study_id: int, cfmm2tar_id: int):
         return answer_info(study_id)
 
     cfmm2tar_output = Cfmm2tarOutput.query.get(cfmm2tar_id)
-    if (cfmm2tar_output is not None) and (
-        cfmm2tar_output.study_id == study_id
-    ):
+    if (cfmm2tar_output is not None) and (cfmm2tar_output.study_id == study_id):
         delete_tar_file(study_id, cfmm2tar_output.tar_file)
         db.session.delete(cfmm2tar_output)  # pyright: ignore
         db.session.commit()  # pyright: ignore
@@ -949,9 +939,7 @@ def run_tar2bids(study_id: int) -> str:
         Cfmm2tarOutput.query.get_or_404(tar_file_id)
         for tar_file_id in form.tar_files.data  # pyright: ignore
     ]
-    tar_files = [
-        tar_file for tar_file in tar_files if tar_file.study_id == study_id
-    ]
+    tar_files = [tar_file for tar_file in tar_files if tar_file.study_id == study_id]
 
     if (
         len(
@@ -1383,8 +1371,7 @@ def list_globus_users() -> Response:
                 "type": dataset.dataset_type.to_bids_str(),
                 "path": f"{path_base}/{dataset.ria_alias}",
                 "users": [
-                    username.username
-                    for username in dataset.study.globus_usernames
+                    username.username for username in dataset.study.globus_usernames
                 ],
             }
             for dataset in DataladDataset.query.filter(

--- a/autobidsportal/routes.py
+++ b/autobidsportal/routes.py
@@ -96,6 +96,17 @@ def index() -> str:
     """
     return render_template("index.html")
 
+@portal_blueprint.route("/getting-started", methods=["GET"])
+def getting_started() -> str:
+    """Render a page with getting started instructions.
+
+    Returns
+    -------
+    str
+        Rendered path for getting staged page
+    """
+    return render_template("getting_started.html")
+
 
 @portal_blueprint.route("/new", methods=["GET", "POST"])
 def new_study() -> str | Response:

--- a/autobidsportal/templates/base.html
+++ b/autobidsportal/templates/base.html
@@ -38,6 +38,9 @@
             <li class="nav-item">
               <a class="nav-link" href="{{ url_for("portal_blueprint.new_study") }}">New Study</a>
             </li>
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for("portal_blueprint.getting_started") }}">Getting Started</a>
+            </li>
             <!-- Non-logged in user -->
             {% if current_user.is_anonymous %}
               <li class="nav-item">

--- a/autobidsportal/templates/getting_started.html
+++ b/autobidsportal/templates/getting_started.html
@@ -1,0 +1,197 @@
+<!-- Home page -->
+{% extends "base.html" %}
+{% block title %}
+  Home
+{% endblock title %}
+{% block
+  app_content %}
+  <div class="container">
+    <!-- Getting started -->
+    <div class="row">
+      <div class="col">
+        <div class="card my-3">
+          <div class="card-body">
+            <h1 class="card-title">Getting started!</h1>
+            <p class="card-text">
+              This page provides some information to help you get started with autobids,
+              detailing the steps taken to convert data acquired from a CFMM scanner to
+              a <a href="https://bids.neuroimaging.io/" target="_blank" rel="noopener">BIDS</a>
+              dataset.
+              <br />
+              <br />
+              If you haven't already, please
+              <a href="{{ url_for("portal_blueprint.register") }}"
+                 target="_blank"
+                 rel="noopener">create an account</a> in order to interact with and
+              manage your study.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- New study -->
+    <div class="row">
+      <div class="col">
+        <div class="card my-3">
+          <div class="card-body">
+            <h2 class="card-title">New study</h2>
+            <p class="card-text">
+              After you have acquired some data from a CFMM scanner, a request can be
+              made for autobids conversion:
+              <ol type="1">
+                <li>
+                  Request a new study from the
+                  <a href="{{ url_for("portal_blueprint.new_study") }}">"New Study"</a>
+                  tab.
+                </li>
+                <li>
+                  Have the PI (or study manager) add "bidsdump" as an authorized user
+                  for the study on the CFMM DICOM server. A step-by-step guide can be found
+                  <a href="https://github.com/khanlab/autobids/wiki/Granting-access-to-bidsdump"
+                     target="_blank"
+                     rel="noopener">here</a>.
+                </li>
+                <li>
+                  Sign up for a <a href="https://app.globus.org/" target="_blank" rel="noopener">Globus</a>
+                  in order to download the converted data.
+                </li>
+              </ol>
+              An admin will review the new study, enable it, and grant you access if
+              there are no issues. Additional users can be granted access to the study.
+              For autobids to work on the study, the "Active" option needs to be checked
+              in the study config.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Cfmm2tar -->
+    <div class="row">
+      <div class="col">
+        <div class="card my-3">
+          <div class="card-body">
+            <h2 class="card-title">DICOM retrieval</h2>
+            <p class="card-text">
+              <em>
+                (This step makes use of
+                <a href="https://github.com/khanlab/cfmm2tar"
+                   target="_blank"
+                   rel="noopener">cfmm2tar</a>)
+              </em>
+              <br>
+              <br>
+              The first step of autobids queries the CFMM DICOM server to look for
+              the study data based on information that was provided when creating a
+              new study. For each newly acquired scan that is found, a tarball file will
+              be created containing all of the associated DICOMS for a given participant.
+              This tarball file will be named based on a combination of values pulled from
+              the DICOM server and autobids database (which will be created if it can't
+              be found):
+              <br>
+              <br>
+              <code>PI_ProjectDescription_ScanDate_PatientName_StudyID.Hash.tar</code>
+              <br>
+              <br>
+              All created tarballs can be found under the "Tar Files" table within a given
+              study. It is important that these tarballs are named consistently as
+              these names are used to organize the data in the next step. The easiest
+              way to ensure this is to have a consistent patient naming patterns when
+              acquiring the data. If renaming is necessary, it can be done by clicking
+              the "Rename" button for each tarball.
+              <br>
+              <br>
+              <!-- Individual subjects -->
+              If you wish to manage individual participants (e.g. exclude from
+              conversion), you can do so by querying the DICOM server via autobids by
+              clicking "All matching scans" on the study page.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Tar2bids -->
+    <div class="row">
+      <div class="col">
+        <div class="card my-3">
+          <div class="card-body">
+            <h2 class="card-title">BIDS-ify data</h2>
+            <p class="card-text">
+              <em>
+                (This step makes use of
+                <a href="https://github.com/khanlab/tar2bids"
+                   target="_blank"
+                   rel="noopener">tar2bids</a>)
+              </em>
+              <br>
+              <br>
+              The next step of autobids uses the previously created tarballs and custom
+              heuristics to map the DICOMS to NifTIs organized according to BIDS. There
+              are two important settings under the study's config page:
+              <ol>
+                <li>Heuristic - study specific mapping of DICOM values</li>
+                <li>
+                  Tar2bids Patient Name Search String - extraction of patient names
+                  and session labels (if necessary)
+                </li>
+              </ol>
+              After the data has been converted, it will be validated according to the
+              BIDS specification. Any errors or warnings will appear here! If the files
+              you converted are not part of the specification, you can add the pattern
+              to the .bidsignore content under the study configuration to exclude them
+              from validation.
+              <br>
+              <br>
+              If the study was acquired on the 7T scanner, distortion correction is
+              automatically performed on the converted data after validation.
+              Additionally, optional defacing can be performed by checking
+              the option under the study config.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Archiving -->
+    <div class="row">
+      <div class="col">
+        <div class="card my-3">
+          <div class="card-body">
+            <h2 class="card-title">Accessing the data</h2>
+            <p class="card-text">
+              Ensure a globus identity has been granted access to the study under the
+              study config, as converted data is archived and shared via globus. Note
+              the study id, which will be in the name of the shared globus collection.
+              In each collection, one zip archive will be created containing the
+              converted data since the last time tar2bids has been run.
+              <br>
+              <br>
+              Instructions for accessing the converted data can be found in the study
+              page.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Notes -->
+    <div class="row">
+      <div class="col">
+        <div class="card my-3">
+          <div class="card-body">
+            <h2 class="card-title">Notes</h2>
+            <p class="card-text">
+              <li>
+                For any questions concerning autobids, please post them on the
+                <a href="https://cbs-discourse.uwo.ca" target="_blank" rel="noopener">
+                  CBS Discourse
+                </a>.
+              </li>
+              <li>
+                Each step noted is automatically run throughout the day,
+                but can also be triggered manually
+              </li>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock app_content %}


### PR DESCRIPTION
This adds a getting started page to the autobids webpage, providing an overview of how autobids works. This is meant to be a starting point as autobids moves more towards having the user manage their own study, with any additional questions being asked via the CBS Discourse page. 